### PR TITLE
Implemente new middleware options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,43 @@ app.get('/', (req, res) => {
 
 // Use the middleware to handle errors.
 app.use(httpErrorMiddleware())
-// If you want the error details to be placed at the root of the response body, set the "destructure" flag to true.
-app.use(httpErrorMiddleware({ destructure: true }))
 // Other middleware for handling errors can go here.
 
 // Start the server.
 app.listen(3000, () => {
   console.log('Server running')
 })
+```
+
+### httpErrorMiddleware settings
+
+The middleware offers some configurations to customize the error response, which are optional.
+
+```typescript
+import express from 'express'
+
+import { httpErrorMiddleware } from 'http-error-middleware'
+
+const app = express()
+//Other Express app config
+
+app.use(httpErrorMiddleware({
+  destructure: false,
+  statusCodeOnResponse: false
+}))
+```
+
+- If you want the error details to be placed at the root of the response body, set the "destructure" flag to true.
+
+- If you want the status code sent to be in the response body, set the "statusCodeOnResponse" flag to true.
+
+The default settings is as follows:
+
+```json
+{
+  "destructure": false,
+  "statusCodeOnResponse": true
+}
 ```
 
 ### Throw Errors Where You Need Them
@@ -57,7 +86,7 @@ This code will throw an error that gets handled by the middleware, and the respo
 ```json
 {
   "message": "Email and/or password are wrong",
-  "statusCode": 400
+  "statusCode": 400 // This property will be removed this if you set the "statusCodeOnResponse" flag to false.
 }
 ```
 
@@ -80,7 +109,7 @@ This will generate a response with additional error details:
     "fieldName": "Error message",
     "fieldName2": "Error message"
   },
-  "statusCode": 400
+  "statusCode": 400 // This property will be removed this if you set the "statusCodeOnResponse" flag to false.
 }
 ```
 
@@ -90,8 +119,8 @@ If you have the "destructure" flag set, the message will be displayed like this:
 {
   "message": "Email and/or password are wrong",
   "fieldName": "Error message",
-  "fieldName2": "Error message"
-  "statusCode": 400
+  "fieldName2": "Error message",
+  "statusCode": 400 // This property will be removed this if you set the "statusCodeOnResponse" flag to false.
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-error-middleware",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/HttpError.ts
+++ b/src/HttpError.ts
@@ -63,8 +63,8 @@ export class HttpError extends Error {
     throw new HttpError(message, ServerErrorCodes.serviceUnavailable, details)
   }
 
-  static gatewayTimeOut(message: string, details?: object) {
-    throw new HttpError(message, ServerErrorCodes.gatewayTimeOut, details)
+  static gatewayTimeout(message: string, details?: object) {
+    throw new HttpError(message, ServerErrorCodes.gatewayTimeout, details)
   }
 
   /**

--- a/src/enums/StatusCode.ts
+++ b/src/enums/StatusCode.ts
@@ -24,5 +24,5 @@ export enum ServerErrorCodes {
   notImplemented = 501,
   badGateway = 502,
   serviceUnavailable = 503,
-  gatewayTimeOut = 504,
+  gatewayTimeout = 504,
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,15 +3,29 @@ import { NextFunction, Request, Response } from 'express'
 import { HttpError } from '@/HttpError'
 
 interface HttpErrorMiddlewareProps {
-  destructure: boolean
+  destructure: boolean,
+  statusCodeOnResponse: boolean
 }
 
 export function httpErrorMiddleware(options: Partial<HttpErrorMiddlewareProps> = {}) {
   return function (err: any, _req: Request, res: Response, next: NextFunction) {
     if (err instanceof HttpError) {
+      const { destructure, statusCodeOnResponse } = options
       const { message, statusCode, details } = err
-      if (options.destructure) res.status(statusCode).json({ message, statusCode, ...details })
-      else res.status(statusCode).json({ message, statusCode, details })
+
+      let allData: any = { message, statusCode, details }
+
+      if (statusCodeOnResponse !== undefined && !statusCodeOnResponse) {
+        const { statusCode:_, ...restData } = allData
+        allData = restData
+      } 
+
+      if (destructure) {
+        const { details: destructureDetails, ...restData } = allData
+        allData = { ...restData, ...destructureDetails }
+      } 
+
+      res.status(statusCode).json({ ...allData })
     } else {
       next(err)
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,8 +4,15 @@ import type { Express } from 'express'
 import { httpErrorMiddleware } from '@/middleware'
 import { HttpError } from '@/HttpError'
 
-export default function app(destructure: boolean): Express {
+interface AppProps {
+  destructure: boolean
+  statusCodeOnResponse: boolean
+}
+
+export default function app(options: Partial<AppProps> = {}): Express {
   const app = express()
+
+  const { destructure, statusCodeOnResponse } = options
 
   app.get('/bad-request', () => {
     HttpError.badRequest('Bad Request', { detailsMessage: 'This are important details' })
@@ -46,13 +53,33 @@ export default function app(destructure: boolean): Express {
   app.get('/conflict', () => {
     HttpError.conflict('Conflict', { detailsMessage: 'This are important details' })
   })
+  
+  app.get('/internal-server-error', () => {
+    HttpError.internalServerError('Internal server error', { detailsMessage: 'This are important details' })
+  })
+  
+  app.get('/not-implemented', () => {
+    HttpError.notImplemented('Not implemented', { detailsMessage: 'This are important details' })
+  })
+  
+  app.get('/bad-gateway', () => {
+    HttpError.badGateway('Bad gateway', { detailsMessage: 'This are important details' })
+  })
+  
+  app.get('/service-unavailable', () => {
+    HttpError.serviceUnavailable('Service unavailable', { detailsMessage: 'This are important details' })
+  })
+  
+  app.get('/gateway-timeout', () => {
+    HttpError.gatewayTimeout('Gateway Timeout', { detailsMessage: 'This are important details' })
+  })
 
   app.get('/custom', (req, _res) => {
     const { statusCode } = req.query
     HttpError.custom('Custom error', Number(statusCode), { detailsMessage: 'This are important details' })
   })
 
-  app.use(httpErrorMiddleware({ destructure }))
+  app.use(httpErrorMiddleware({ destructure, statusCodeOnResponse }))
 
   return app
 }

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -2,15 +2,17 @@ import request from 'supertest'
 import http from 'http'
 
 import app from '@/server'
-import { ClientErrorCodes } from '@/enums/StatusCode'
+import { ClientErrorCodes, ServerErrorCodes } from '@/enums/StatusCode'
 
-const server = http.createServer(app(false)).listen(3000)
-const server2 = http.createServer(app(true)).listen(3001)
+const server = http.createServer(app({ destructure: false, statusCodeOnResponse: false })).listen(3000)
+const server2 = http.createServer(app({ destructure: true, statusCodeOnResponse: true })).listen(3001)
 
 describe('GET', () => {
+  // Client errors
   test('try to get a bad request response', async () => {
     const response = await request(server).get('/bad-request').send()
     expect(response.status).toBe(ClientErrorCodes.badRequest)
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.body.message).toBe('Bad Request')
     expect(response.body.details.detailsMessage).toBe('This are important details')
   })
@@ -18,6 +20,7 @@ describe('GET', () => {
   test('try to get a unauthorized response', async () => {
     const response = await request(server).get('/unauthorized').send()
     expect(response.status).toBe(ClientErrorCodes.unauthorized)
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.body.message).toBe('Unauthorized')
     expect(response.body.details.detailsMessage).toBe('This are important details')
   })
@@ -25,6 +28,7 @@ describe('GET', () => {
   test('try to get a payment required response', async () => {
     const response = await request(server).get('/payment-required').send()
     expect(response.status).toBe(ClientErrorCodes.paymentRequired)
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.body.message).toBe('Payment required')
     expect(response.body.details.detailsMessage).toBe('This are important details')
   })
@@ -32,12 +36,14 @@ describe('GET', () => {
   test('try to get a not forbidden response', async () => {
     const response = await request(server).get('/forbidden').send()
     expect(response.status).toBe(ClientErrorCodes.forbidden)
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.body.message).toBe('Forbidden')
     expect(response.body.details.detailsMessage).toBe('This are important details')
   })
 
   test('try to get a not not found response', async () => {
     const response = await request(server).get('/not-found').send()
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.status).toBe(ClientErrorCodes.notFound)
     expect(response.body.message).toBe('Not found')
     expect(response.body.details.detailsMessage).toBe('This are important details')
@@ -46,6 +52,7 @@ describe('GET', () => {
   test('try to get a method not allowed response', async () => {
     const response = await request(server).get('/method-not-allowed').send()
     expect(response.status).toBe(ClientErrorCodes.methodNotAllowed)
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.body.message).toBe('Method not allowed')
     expect(response.body.details.detailsMessage).toBe('This are important details')
   })
@@ -53,6 +60,7 @@ describe('GET', () => {
   test('try to get a not acceptable response', async () => {
     const response = await request(server).get('/not-acceptable').send()
     expect(response.status).toBe(ClientErrorCodes.notAcceptable)
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.body.message).toBe('Not acceptable')
     expect(response.body.details.detailsMessage).toBe('This are important details')
   })
@@ -60,6 +68,7 @@ describe('GET', () => {
   test('try to get a proxy authentication required response', async () => {
     const response = await request(server).get('/proxy-authentication-requerid').send()
     expect(response.status).toBe(ClientErrorCodes.proxyAuthenticationRequired)
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.body.message).toBe('Proxy authentication required')
     expect(response.body.details.detailsMessage).toBe('This are important details')
   })
@@ -67,6 +76,7 @@ describe('GET', () => {
   test('try to get a request timeout response', async () => {
     const response = await request(server).get('/request-timeout').send()
     expect(response.status).toBe(ClientErrorCodes.requestTimeOut)
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.body.message).toBe('Request timeout')
     expect(response.body.details.detailsMessage).toBe('This are important details')
   })
@@ -74,7 +84,48 @@ describe('GET', () => {
   test('try to get a conflict response', async () => {
     const response = await request(server).get('/conflict').send()
     expect(response.status).toBe(ClientErrorCodes.conflict)
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.body.message).toBe('Conflict')
+    expect(response.body.details.detailsMessage).toBe('This are important details')
+  })
+
+  test('try to get a internal server error response', async () => {
+    const response = await request(server).get('/internal-server-error').send()
+    expect(response.body.statusCode).toBe(undefined)
+    expect(response.status).toBe(ServerErrorCodes.internalServerError)
+    expect(response.body.message).toBe('Internal server error')
+    expect(response.body.details.detailsMessage).toBe('This are important details')
+  })
+
+  test('try to get a not implement response', async () => {
+    const response = await request(server).get('/not-implemented').send()
+    expect(response.body.statusCode).toBe(undefined)
+    expect(response.status).toBe(ServerErrorCodes.notImplemented)
+    expect(response.body.message).toBe('Not implemented')
+    expect(response.body.details.detailsMessage).toBe('This are important details')
+  })
+
+  test('try to get a bat gateway response', async () => {
+    const response = await request(server).get('/bad-gateway').send()
+    expect(response.body.statusCode).toBe(undefined)
+    expect(response.status).toBe(ServerErrorCodes.badGateway)
+    expect(response.body.message).toBe('Bad gateway')
+    expect(response.body.details.detailsMessage).toBe('This are important details')
+  })
+
+  test('try to get a service unavailable response', async () => {
+    const response = await request(server).get('/service-unavailable').send()
+    expect(response.body.statusCode).toBe(undefined)
+    expect(response.status).toBe(ServerErrorCodes.serviceUnavailable)
+    expect(response.body.message).toBe('Service unavailable')
+    expect(response.body.details.detailsMessage).toBe('This are important details')
+  })
+
+  test('try to get a bat gateway response', async () => {
+    const response = await request(server).get('/gateway-timeout').send()
+    expect(response.body.statusCode).toBe(undefined)
+    expect(response.status).toBe(ServerErrorCodes.gatewayTimeout)
+    expect(response.body.message).toBe('Gateway Timeout')
     expect(response.body.details.detailsMessage).toBe('This are important details')
   })
 
@@ -84,6 +135,7 @@ describe('GET', () => {
       .query({ statusCode: 400 })
       .send()
     expect(response.status).toBe(ClientErrorCodes.badRequest)
+    expect(response.body.statusCode).toBe(undefined)
     expect(response.body.message).toBe('Custom error')
     expect(response.body.details.detailsMessage).toBe('This are important details')
   })
@@ -94,37 +146,43 @@ describe('GET', () => {
 })
 
 describe('GET destructure', () => {
+  // Client errors
   test('try to get a bad request response', async () => {
     const response = await request(server2).get('/bad-request').send()
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(ClientErrorCodes.badRequest)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.badRequest)
     expect(response.body.message).toBe('Bad Request')
     expect(response.body.detailsMessage).toBe('This are important details')
   })
 
   test('try to get a unauthorized response', async () => {
     const response = await request(server2).get('/unauthorized').send()
-    expect(response.status).toBe(401)
+    expect(response.status).toBe(ClientErrorCodes.unauthorized)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.unauthorized)
     expect(response.body.message).toBe('Unauthorized')
     expect(response.body.detailsMessage).toBe('This are important details')
   })
 
   test('try to get a payment required response', async () => {
     const response = await request(server2).get('/payment-required').send()
-    expect(response.status).toBe(402)
+    expect(response.status).toBe(ClientErrorCodes.paymentRequired)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.paymentRequired)
     expect(response.body.message).toBe('Payment required')
     expect(response.body.detailsMessage).toBe('This are important details')
   })
 
   test('try to get a not forbidden response', async () => {
     const response = await request(server2).get('/forbidden').send()
-    expect(response.status).toBe(403)
+    expect(response.status).toBe(ClientErrorCodes.forbidden)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.forbidden)
     expect(response.body.message).toBe('Forbidden')
     expect(response.body.detailsMessage).toBe('This are important details')
   })
 
   test('try to get a not not found response', async () => {
     const response = await request(server2).get('/not-found').send()
-    expect(response.status).toBe(404)
+    expect(response.status).toBe(ClientErrorCodes.notFound)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.notFound)
     expect(response.body.message).toBe('Not found')
     expect(response.body.detailsMessage).toBe('This are important details')
   })
@@ -132,6 +190,7 @@ describe('GET destructure', () => {
   test('try to get a method not allowed response', async () => {
     const response = await request(server2).get('/method-not-allowed').send()
     expect(response.status).toBe(ClientErrorCodes.methodNotAllowed)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.methodNotAllowed)
     expect(response.body.message).toBe('Method not allowed')
     expect(response.body.detailsMessage).toBe('This are important details')
   })
@@ -139,6 +198,7 @@ describe('GET destructure', () => {
   test('try to get a not acceptable response', async () => {
     const response = await request(server2).get('/not-acceptable').send()
     expect(response.status).toBe(ClientErrorCodes.notAcceptable)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.notAcceptable)
     expect(response.body.message).toBe('Not acceptable')
     expect(response.body.detailsMessage).toBe('This are important details')
   })
@@ -146,6 +206,7 @@ describe('GET destructure', () => {
   test('try to get a proxy authentication required response', async () => {
     const response = await request(server2).get('/proxy-authentication-requerid').send()
     expect(response.status).toBe(ClientErrorCodes.proxyAuthenticationRequired)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.proxyAuthenticationRequired)
     expect(response.body.message).toBe('Proxy authentication required')
     expect(response.body.detailsMessage).toBe('This are important details')
   })
@@ -153,6 +214,7 @@ describe('GET destructure', () => {
   test('try to get a request timeout response', async () => {
     const response = await request(server2).get('/request-timeout').send()
     expect(response.status).toBe(ClientErrorCodes.requestTimeOut)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.requestTimeOut)
     expect(response.body.message).toBe('Request timeout')
     expect(response.body.detailsMessage).toBe('This are important details')
   })
@@ -160,7 +222,48 @@ describe('GET destructure', () => {
   test('try to get a conflict response', async () => {
     const response = await request(server2).get('/conflict').send()
     expect(response.status).toBe(ClientErrorCodes.conflict)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.conflict)
     expect(response.body.message).toBe('Conflict')
+    expect(response.body.detailsMessage).toBe('This are important details')
+  })
+
+  test('try to get a internal server error response', async () => {
+    const response = await request(server2).get('/internal-server-error').send()
+    expect(response.status).toBe(ServerErrorCodes.internalServerError)
+    expect(response.body.statusCode).toBe(ServerErrorCodes.internalServerError)
+    expect(response.body.message).toBe('Internal server error')
+    expect(response.body.detailsMessage).toBe('This are important details')
+  })
+
+  test('try to get a not implement response', async () => {
+    const response = await request(server2).get('/not-implemented').send()
+    expect(response.status).toBe(ServerErrorCodes.notImplemented)
+    expect(response.body.statusCode).toBe(ServerErrorCodes.notImplemented)
+    expect(response.body.message).toBe('Not implemented')
+    expect(response.body.detailsMessage).toBe('This are important details')
+  })
+
+  test('try to get a bat gateway response', async () => {
+    const response = await request(server2).get('/bad-gateway').send()
+    expect(response.body.statusCode).toBe(ServerErrorCodes.badGateway)
+    expect(response.status).toBe(ServerErrorCodes.badGateway)
+    expect(response.body.message).toBe('Bad gateway')
+    expect(response.body.detailsMessage).toBe('This are important details')
+  })
+
+  test('try to get a service unavailable response', async () => {
+    const response = await request(server2).get('/service-unavailable').send()
+    expect(response.status).toBe(ServerErrorCodes.serviceUnavailable)
+    expect(response.body.statusCode).toBe(ServerErrorCodes.serviceUnavailable)
+    expect(response.body.message).toBe('Service unavailable')
+    expect(response.body.detailsMessage).toBe('This are important details')
+  })
+
+  test('try to get a bat gateway response', async () => {
+    const response = await request(server2).get('/gateway-timeout').send()
+    expect(response.status).toBe(ServerErrorCodes.gatewayTimeout)
+    expect(response.body.statusCode).toBe(ServerErrorCodes.gatewayTimeout)
+    expect(response.body.message).toBe('Gateway Timeout')
     expect(response.body.detailsMessage).toBe('This are important details')
   })
 
@@ -170,6 +273,7 @@ describe('GET destructure', () => {
       .query({ statusCode: 400 })
       .send()
     expect(response.status).toBe(ClientErrorCodes.badRequest)
+    expect(response.body.statusCode).toBe(ClientErrorCodes.badRequest)
     expect(response.body.message).toBe('Custom error')
     expect(response.body.detailsMessage).toBe('This are important details')
   })


### PR DESCRIPTION
If you want the status code sent to be in the response body, set the "statusCodeOnResponse" flag to true.